### PR TITLE
Create command for adding restrict ips

### DIFF
--- a/Command/AddRestrictIp.php
+++ b/Command/AddRestrictIp.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace MSP\AdminRestriction\Command;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use MSP\AdminRestriction\Api\RestrictInterface;
+use Magento\Framework\App\Config\ConfigResource\ConfigInterface;
+use MSP\AdminRestriction\Model\Restrict;
+
+class AddRestrictIp extends Command
+{
+    public function __construct(
+        private readonly ScopeConfigInterface $config,
+        private readonly ConfigInterface      $scopeConfig,
+        private readonly RestrictInterface    $restrict,
+    )
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->setName('msp:security:admin_restriction:add_ip');
+        $this->setDescription('Add IP to Admin Restriction');
+        $this->addArgument('ip', InputArgument::REQUIRED, __('Authorized comma separated IP list'));
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $inputIps = $input->getArgument('ip');
+        $ips = explode(',', $inputIps);
+        $changes = [];
+        $allowedList = $this->restrict->getAllowedRanges();
+
+        // Loop over ips
+        foreach ($ips as $ip) {
+            try {
+                $this->validateIP($ip);
+            } catch (\InvalidArgumentException $e) {
+                $output->writeln(sprintf('<error>%s</error>', $e->getMessage()));
+                return 1;
+            }
+
+            if (in_array($ip, $allowedList)) {
+                $output->writeln(sprintf('<info>IP %s already exists</info>', $ip));
+                continue;
+            }
+
+            $changes[] = $ip;
+        }
+
+        if (!$changes) {
+            $output->writeln('<info>No changes have been made</info>');
+            return 0;
+        }
+
+        $this->scopeConfig->saveConfig(
+            RestrictInterface::XML_PATH_AUTHORIZED_RANGES,
+            implode(',', array_merge($allowedList, $changes))
+        );
+
+        $output->writeln(sprintf('<info>IPs %s will be added to the list</info>', implode(', ', $changes)));
+
+        return 0;
+    }
+
+    private function validateIP(string $ip): void
+    {
+        if (!filter_var($ip, FILTER_VALIDATE_IP)) {
+            throw new \InvalidArgumentException(sprintf('Invalid IP address: %s', $ip));
+        }
+    }
+}

--- a/Command/AddRestrictIp.php
+++ b/Command/AddRestrictIp.php
@@ -1,20 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MSP\AdminRestriction\Command;
 
-use Magento\Framework\App\Config\ScopeConfigInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use MSP\AdminRestriction\Api\RestrictInterface;
 use Magento\Framework\App\Config\ConfigResource\ConfigInterface;
-use MSP\AdminRestriction\Model\Restrict;
 
 class AddRestrictIp extends Command
 {
     public function __construct(
-        private readonly ScopeConfigInterface $config,
         private readonly ConfigInterface      $scopeConfig,
         private readonly RestrictInterface    $restrict,
     )
@@ -26,7 +25,11 @@ class AddRestrictIp extends Command
     {
         $this->setName('msp:security:admin_restriction:add_ip');
         $this->setDescription('Add IP to Admin Restriction');
-        $this->addArgument('ip', InputArgument::REQUIRED, __('Authorized comma separated IP list'));
+        $this->addArgument(
+            'ip',
+            InputArgument::REQUIRED,
+            __('Authorized comma separated IP list')->render()
+        );
     }
 
     public function execute(InputInterface $input, OutputInterface $output): int
@@ -36,7 +39,6 @@ class AddRestrictIp extends Command
         $changes = [];
         $allowedList = $this->restrict->getAllowedRanges();
 
-        // Loop over ips
         foreach ($ips as $ip) {
             try {
                 $this->validateIP($ip);
@@ -53,7 +55,7 @@ class AddRestrictIp extends Command
             $changes[] = $ip;
         }
 
-        if (!$changes) {
+        if (empty($changes)) {
             $output->writeln('<info>No changes have been made</info>');
             return 0;
         }

--- a/Command/AddRestrictIp.php
+++ b/Command/AddRestrictIp.php
@@ -13,7 +13,7 @@ use Magento\Framework\App\Config\ConfigResource\ConfigInterface;
 
 class AddRestrictIp extends Command
 {
-    private const string ARG_IP = 'ip';
+    private const ARG_IP = 'ip';
 
     public function __construct(
         private readonly ConfigInterface $scopeConfig,

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -26,7 +26,8 @@
     <type name="Magento\Framework\Console\CommandList">
         <arguments>
             <argument name="commands" xsi:type="array">
-                <item name="msp_adminrestriction" xsi:type="object">MSP\AdminRestriction\Command\RestrictIp</item>
+                <item name="msp_adminrestriction_add_ip" xsi:type="object">MSP\AdminRestriction\Command\AddRestrictIp</item>
+                <item name="msp_adminrestriction_replace_ip" xsi:type="object">MSP\AdminRestriction\Command\RestrictIp</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
### Add Console Command to Add IPs to Admin Restriction
This PR introduces a new CLI command:  
`msp:security:admin_restriction:add_ip`

#### Features:
- **Validates** each IP address format.
- **Skips** IPs that are already in the allowed list.
- Updates the admin restriction config **only if new IPs are added**.

#### Example:
```bash
bin/magento msp:security:admin_restriction:add_ip 192.168.0.1,10.0.0.2
```

Closes #2 